### PR TITLE
set sentry raven logger to provided logger

### DIFF
--- a/lib/travis/exceptions/reporter/raven.rb
+++ b/lib/travis/exceptions/reporter/raven.rb
@@ -29,6 +29,7 @@ module Travis
             logger.info(MSGS[:setup] % [strip_password(config[:sentry][:dsn]), env])
 
             ::Raven.configure do |c|
+              c.logger = logger
               c.dsn  = config[:sentry][:dsn]
               c.ssl  = config[:ssl] if config[:ssl]
               c.tags = { environment: env }


### PR DESCRIPTION
this is useful if you want it to log somewhere else, such as stderr.

refs travis-ci/travis-scheduler#93